### PR TITLE
feat(ui): cambiar label de 'Find owners' en layout principal

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -43,9 +43,9 @@
             <span th:text="#{home}">Home</span>
           </li>
 
-          <li th:replace="~{::menuItem ('/owners/find','owners','find owners','search',#{findOwners})}">
+          <li th:replace="~{::menuItem ('/owners/find','owners','find owners','search',#{owners})}">
             <span class="fa fa-search" aria-hidden="true"></span>
-            <span th:text="#{findOwners}">Find owners</span>
+            <span th:text="#{owners}">Find owners</span>
           </li>
 
           <li th:replace="~{::menuItem ('/vets.html','vets','veterinarians','th-list',#{vets})}">


### PR DESCRIPTION
## Resumen
Actualización del texto del enlace de navegación "Find owners" en el layout principal de la aplicación para mejorar la experiencia de usuario.

## Cambios Realizados
- Modificado el archivo `src/main/resources/templates/fragments/layout.html`
- Actualizado el texto del enlace de navegación en el menú principal
- Cambio aplicado tanto en la versión normal como en la versión activa del enlace

## Archivos Modificados
- `src/main/resources/templates/fragments/layout.html`

## Pruebas
- ✅ Las pruebas principales del proyecto han pasado exitosamente (56/58)
- ⚠️ 2 pruebas de PostgresIntegrationTests fallan por problemas de configuración de Docker/Podman (no relacionados con este cambio)

Resolve: #3