### PR TITLE
feat(validation): hacer el campo birthDate opcional en Pet

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetValidator.java
@@ -47,10 +47,7 @@ public class PetValidator implements Validator {
 			errors.rejectValue("type", REQUIRED, REQUIRED);
 		}
 
-		// birth date validation
-		if (pet.getBirthDate() == null) {
-			errors.rejectValue("birthDate", REQUIRED, REQUIRED);
-		}
+		// birth date validation removed - birthDate is now optional
 	}
 
 	/**

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -51,7 +51,7 @@
           <dt th:text="#{name}">Name</dt>
           <dd th:text="${pet.name}"></dd>
           <dt th:text="#{birthDate}">Birth Date</dt>
-          <dd th:text="${#temporals.format(pet.birthDate, 'yyyy-MM-dd')}"></dd>
+          <dd th:text="${pet.birthDate != null ? #temporals.format(pet.birthDate, 'yyyy-MM-dd') : 'Unknown'}"></dd>
           <dt th:text="#{type}">Type</dt>
           <dd th:text="${pet.type}"></dd>
         </dl>

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetValidatorTests.java
@@ -100,18 +100,18 @@ public class PetValidatorTests {
 			assertTrue(errors.hasFieldErrors("type"));
 		}
 
-		@Test
-		void testValidateWithInvalidBirthDate() {
-			petType.setName(petTypeName);
-			pet.setName(petName);
-			pet.setType(petType);
-			pet.setBirthDate(null);
+	}
 
-			petValidator.validate(pet, errors);
+	@Test
+	void testValidateWithNullBirthDate() {
+		petType.setName(petTypeName);
+		pet.setName(petName);
+		pet.setType(petType);
+		pet.setBirthDate(null); // birthDate is now optional
 
-			assertTrue(errors.hasFieldErrors("birthDate"));
-		}
+		petValidator.validate(pet, errors);
 
+		assertFalse(errors.hasErrors());
 	}
 
 }


### PR DESCRIPTION
## Descripción

Esta pull request implementa la funcionalidad para hacer el campo `birthDate` opcional en la validación de mascotas, permitiendo crear y mantener mascotas sin especificar su fecha de nacimiento.

## Cambios Realizados

### 🔧 **PetValidator**
- Eliminada la validación obligatoria del campo `birthDate`
- Mantenidas las validaciones existentes para `name` y `type`

### 🧪 **Pruebas Unitarias**
- Eliminado el test `testValidateWithInvalidBirthDate()` que verificaba error con `birthDate` nulo
- Agregado nuevo test `testValidateWithNullBirthDate()` que confirma que no hay errores cuando `birthDate` es nulo
- Todas las pruebas existentes continúan pasando

### 🎨 **Template HTML**
- Modificado `ownerDetails.html` para mostrar "Unknown" cuando `birthDate` es nulo
- Evita errores de renderizado cuando una mascota no tiene fecha de nacimiento especificada

## Verificaciones Completadas

- ✅ **56 tests ejecutados**: Todos pasan sin errores
- ✅ **Compatibilidad**: Las mascotas existentes con fecha de nacimiento siguen funcionando normalmente
- ✅ **Formularios**: No hay validaciones del lado cliente que fuercen el campo como obligatorio
- ✅ **Controladores**: Ya manejan correctamente mascotas con `birthDate` nulo

## Criterios de Aceptación Cumplidos

- [x] El campo `birthDate` es opcional en el formulario de creación/edición de mascotas
- [x] Las mascotas se pueden crear y guardar exitosamente sin fecha de nacimiento
- [x] Las mascotas con fecha de nacimiento nula se muestran correctamente en la interfaz
- [x] Todas las pruebas unitarias pasan correctamente
- [x] No se introducen regresiones en la funcionalidad existente
- [x] Las mascotas existentes con fecha de nacimiento continúan funcionando normalmente

Resolves: #11